### PR TITLE
[Common] 메인화면에서 사용될 SF Image 상수화

### DIFF
--- a/ZURAZU/ZURAZU.xcodeproj/project.pbxproj
+++ b/ZURAZU/ZURAZU.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		BD88BB4F2643ABE30029CCC6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD88BB4D2643ABE30029CCC6 /* LaunchScreen.storyboard */; };
 		BD88BB5A2643ABE30029CCC6 /* ZURAZUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD88BB592643ABE30029CCC6 /* ZURAZUTests.swift */; };
 		BD88BB652643ABE30029CCC6 /* ZURAZUUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD88BB642643ABE30029CCC6 /* ZURAZUUITests.swift */; };
+		BD88BBD02644BD940029CCC6 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD88BBCF2644BD940029CCC6 /* Image.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +58,7 @@
 		BD88BB602643ABE30029CCC6 /* ZURAZUUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZURAZUUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD88BB642643ABE30029CCC6 /* ZURAZUUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZURAZUUITests.swift; sourceTree = "<group>"; };
 		BD88BB662643ABE30029CCC6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BD88BBCF2644BD940029CCC6 /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		C6C14E90244A7910B30570D9 /* Pods-ZURAZUTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZURAZUTests.debug.xcconfig"; path = "Target Support Files/Pods-ZURAZUTests/Pods-ZURAZUTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D112E81F6ADCE03F2C0351B6 /* Pods_ZURAZUTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ZURAZUTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -143,6 +145,7 @@
 				BD88BB502643ABE30029CCC6 /* Info.plist */,
 				BD88BB482643ABDF0029CCC6 /* Main.storyboard */,
 				BD88BB4D2643ABE30029CCC6 /* LaunchScreen.storyboard */,
+				BD88BBD42644BD9A0029CCC6 /* Constant */,
 			);
 			path = ZURAZU;
 			sourceTree = "<group>";
@@ -163,6 +166,14 @@
 				BD88BB662643ABE30029CCC6 /* Info.plist */,
 			);
 			path = ZURAZUUITests;
+			sourceTree = "<group>";
+		};
+		BD88BBD42644BD9A0029CCC6 /* Constant */ = {
+			isa = PBXGroup;
+			children = (
+				BD88BBCF2644BD940029CCC6 /* Image.swift */,
+			);
+			path = Constant;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -423,6 +434,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BD88BB432643ABDF0029CCC6 /* AppDelegate.swift in Sources */,
+				BD88BBD02644BD940029CCC6 /* Image.swift in Sources */,
 				BD88BB452643ABDF0029CCC6 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ZURAZU/ZURAZU/Constant/Image.swift
+++ b/ZURAZU/ZURAZU/Constant/Image.swift
@@ -1,0 +1,19 @@
+//
+//  Image.swift
+//  ZURAZU
+//
+//  Created by 서명렬 on 2021/05/07.
+//
+
+import UIKit
+
+extension UIImage {
+  
+  static let category: UIImage? = UIImage(systemName: "text.alignleft")
+  static let bell: UIImage? = UIImage(systemName: "bell")
+  static let like: UIImage? = UIImage(systemName: "heart")
+  static let likeFill: UIImage? = UIImage(systemName: "heart.fill")
+  static let myPage: UIImage? = UIImage(systemName: "person")
+  static let transactionDetail: UIImage? = UIImage(systemName: "doc.text")
+  static let saleRequest: UIImage? = UIImage(systemName: "plus.app")
+}


### PR DESCRIPTION
## 구현내용
- 메인화면에서 기본적으로 쓰일 이미지 상수화
- 네이밍은 회의를 통해 변경될 수 있음
- 이후 다른 SFImage 또한 추가될 수 있음

### 화면(optional)
메인화면

### 학습 내용(optional)
X

## 논의사항
상수화된 이미지의 네이밍의 경우 명확성을 위한 변경될 수 있을 것 같습니다.
앞으로 추가될 이미지의 경우에도 상의를 통해 네이밍을 했으면 좋겠습니다. :)
