### PR TITLE
[FEAT] MemberAPITest 코드 수정

### DIFF
--- a/ZURAZU/ZURAZUTests/MemberAPITest.swift
+++ b/ZURAZU/ZURAZUTests/MemberAPITest.swift
@@ -22,9 +22,7 @@ class MemberAPITest: XCTestCase {
     
     let testPublisher: AnyPublisher<Result<BaseUser<RegisterResponseData>, NetworkError>, Never> = router.request(route: TestEndPoint.register(email: testEmail, password: testPassword))
     
-    testPublisher.sink { _ in
-      
-    } receiveValue: { result in
+    testPublisher.sink { result in
       switch result {
       case .success(let data):
         if data.status == "OK", data.message == "DB에 등록 성공" {
@@ -47,9 +45,7 @@ class MemberAPITest: XCTestCase {
     
     let testPublisher: AnyPublisher<Result<BaseUser<LoginResponseData>, NetworkError>, Never> = router.request(route: TestEndPoint.login(email: testEmail, password: testPassword))
     
-    testPublisher.sink { _ in
-      
-    } receiveValue: { result in
+    testPublisher.sink { result in
       switch result {
       case .success(let data):
         if data.status == "OK", data.message == "로그인 성공", data.data!.accessToken == "testAccessToken", data.data!.refreshToken == "testRefreshToken" {
@@ -71,9 +67,7 @@ class MemberAPITest: XCTestCase {
     
     let testPublisher: AnyPublisher<Result<BaseUser<RefreshTokenResponseData>, NetworkError>, Never> = router.request(route: TestEndPoint.refreshToken(refreshToken: refreshToken))
     
-    testPublisher.sink { _ in
-      
-    } receiveValue: { result in
+    testPublisher.sink { result in
       switch result {
       case .success(let data):
         if data.status == "OK", data.message == "재발급 성공", data.data!.accessToken == "testAccessToken" {


### PR DESCRIPTION
## 구현내용
- sink 를 사용할 때 receiveCompletion closure부분을 삭제했습니다.
- 혹시나 테스트할 때 필요할까봐 남겨놨는데 비어있는 부분이 어색해서 지워버렸습니다.
### 화면(optional)
X

### 학습 내용(optional)
sink의 경우
`sink(receiveValue: , receiveCompletion: )`과 `sink(receiveValue: ) `로 사용할 수 있습니다.

## 논의사항
X