### PR TITLE
SceneCoordinator Singleton으로 변경

### DIFF
--- a/ZURAZU/ZURAZU/Category/View/CategoryScene.swift
+++ b/ZURAZU/ZURAZU/Category/View/CategoryScene.swift
@@ -12,7 +12,6 @@ struct CategoryScene: Scene {
   var storyboard: String {
     return "Category"
   }
-  var sceneCoordinator: SceneCoordinatorType
   
   func instantiate() -> UIViewController {
     let navigationController: UINavigationController = self.navigationController(identifier: .categoryNavC)
@@ -20,7 +19,7 @@ struct CategoryScene: Scene {
     guard var categoryViewController: CategoryViewController = navigationController.viewControllers.first as? CategoryViewController
     else { fatalError() }
     
-    let viewModel: CategoryViewModel = .init(sceneCoordinator: sceneCoordinator)
+    let viewModel: CategoryViewModel = .init()
     categoryViewController.bind(viewModel: viewModel)
     
     return navigationController

--- a/ZURAZU/ZURAZU/Category/ViewModel/CategoryViewModel.swift
+++ b/ZURAZU/ZURAZU/Category/ViewModel/CategoryViewModel.swift
@@ -19,12 +19,9 @@ final class CategoryViewModel: CategoryViewModelType {
   var mainCategories: PassthroughSubject<[MainCategory], Never> = .init()
   var startFetching: PassthroughSubject<Void, Never> = .init()
   
-  private let sceneCoordinator: SceneCoordinatorType
   private var cancellables: Set<AnyCancellable> = []
   
-  init(sceneCoordinator: SceneCoordinatorType) {
-    self.sceneCoordinator = sceneCoordinator
-    
+  init() {
     bind()
   }
 }

--- a/ZURAZU/ZURAZU/CategoryDetail/View/CategoryDetailScene.swift
+++ b/ZURAZU/ZURAZU/CategoryDetail/View/CategoryDetailScene.swift
@@ -12,7 +12,6 @@ struct CategoryDetailScene: Scene {
   var storyboard: String {
     return "CategoryDetail"
   }
-  var sceneCoordinator: SceneCoordinatorType
   
   func instantiate() -> UIViewController {
     guard var categoryDetailViewController: CategoryDetailViewController = self.viewController(identifier: .categoryDetailVC) as? CategoryDetailViewController

--- a/ZURAZU/ZURAZU/ItemDetail/View/ItemDetailScene.swift
+++ b/ZURAZU/ZURAZU/ItemDetail/View/ItemDetailScene.swift
@@ -10,13 +10,12 @@ import UIKit
 struct ItemDetailScene: Scene {
   
   var storyboard: String
-  var sceneCoordinator: SceneCoordinatorType
   
   func instantiate() -> UIViewController {
     guard var itemDetailViewController: ItemDetailViewController = self.viewController(identifier: .ItemDetailVC) as? ItemDetailViewController
     else { fatalError() }
     
-    let viewModel: ItemDetailViewModel = .init(sceneCoordinator: sceneCoordinator)
+    let viewModel: ItemDetailViewModel = .init()
     itemDetailViewController.bind(viewModel: viewModel)
     
     return itemDetailViewController

--- a/ZURAZU/ZURAZU/ItemDetail/ViewModel/ItemDetailViewModel.swift
+++ b/ZURAZU/ZURAZU/ItemDetail/ViewModel/ItemDetailViewModel.swift
@@ -13,10 +13,4 @@ protocol ItemDetailViewModelType {
 
 final class ItemDetailViewModel: ItemDetailViewModelType {
   
-  let sceneCoordinator: SceneCoordinatorType
-  
-  init(sceneCoordinator: SceneCoordinatorType) {
-    self.sceneCoordinator = sceneCoordinator
-  }
-  
 }

--- a/ZURAZU/ZURAZU/Main/MainTabBarScene.swift
+++ b/ZURAZU/ZURAZU/Main/MainTabBarScene.swift
@@ -13,27 +13,25 @@ struct MainTabBarScene: Scene {
     return "MainTabBar"
   }
   
-  var sceneCoordinator: SceneCoordinatorType
-  
   func instantiate() -> UIViewController {
     guard var tabBarController: MainTabBarController = self.tabBarController(identifier: .mainTabBarC) as? MainTabBarController
     else { fatalError() }
     
-    let viewModel: MainTabBarViewModel = .init(sceneCoordinator: sceneCoordinator)
+    let viewModel: MainTabBarViewModel = .init()
     tabBarController.bind(viewModel: viewModel)
     // MARK: - 화면이 추가된 후 각각의 화면으로 변경해줘야 함
-    let categoryScene: UIViewController = CategoryScene(sceneCoordinator: sceneCoordinator).instantiate()
+    let categoryScene: UIViewController = CategoryScene().instantiate()
     categoryScene.tabBarItem = UITabBarItem(title: "카테고리", image: .textAlignLeft, selectedImage: .textAlignLeft)
     
-    let logScene: UIViewController = MainScene(sceneCoordinator: sceneCoordinator).instantiate()
+    let logScene: UIViewController = MainScene().instantiate()
     logScene.tabBarItem = UITabBarItem(title: "거래내역", image: .docText, selectedImage: .docTextFill)
     
-    let mainScene: UIViewController = MainScene(sceneCoordinator: sceneCoordinator).instantiate()
+    let mainScene: UIViewController = MainScene().instantiate()
     
-    let likeScene: UIViewController = MainScene(sceneCoordinator: sceneCoordinator).instantiate()
+    let likeScene: UIViewController = MainScene().instantiate()
     likeScene.tabBarItem = UITabBarItem(title: "좋아요", image: .heart, selectedImage: .heartFill)
     
-    let myPageScene: UIViewController = MainScene(sceneCoordinator: sceneCoordinator).instantiate()
+    let myPageScene: UIViewController = MainScene().instantiate()
     myPageScene.tabBarItem = UITabBarItem(title: "마이페이지", image: .person, selectedImage: .personFill)
     
     tabBarController.setViewControllers([categoryScene, logScene, mainScene, likeScene, myPageScene], animated: false)

--- a/ZURAZU/ZURAZU/Main/MainTabBarViewModel.swift
+++ b/ZURAZU/ZURAZU/Main/MainTabBarViewModel.swift
@@ -14,13 +14,7 @@ protocol MainTabBarViewModelType {
 
 final class MainTabBarViewModel: MainTabBarViewModelType {
   
-  private let sceneCoordinator: SceneCoordinatorType
-  
-  init(sceneCoordinator: SceneCoordinatorType) {
-    self.sceneCoordinator = sceneCoordinator
-  }
-  
   func tabItemDidSelect() {
-    sceneCoordinator.tabTransition()
+    SceneCoordinator.shared.tabTransition()
   }
 }

--- a/ZURAZU/ZURAZU/Main/View/MainScene.swift
+++ b/ZURAZU/ZURAZU/Main/View/MainScene.swift
@@ -12,7 +12,6 @@ struct MainScene: Scene {
   var storyboard: String {
     return "Main"
   }
-  var sceneCoordinator: SceneCoordinatorType
   
   func instantiate() -> UIViewController {
     let navigationController: UINavigationController = self.navigationController(identifier: .mainNavC)

--- a/ZURAZU/ZURAZU/SceneCoordinator/Scene.swift
+++ b/ZURAZU/ZURAZU/SceneCoordinator/Scene.swift
@@ -10,7 +10,6 @@ import UIKit
 protocol Scene {
   
   var storyboard: String { get }
-  var sceneCoordinator: SceneCoordinatorType { get }
   
   func instantiate() -> UIViewController
 }

--- a/ZURAZU/ZURAZU/SceneCoordinator/SceneCoordinator.swift
+++ b/ZURAZU/ZURAZU/SceneCoordinator/SceneCoordinator.swift
@@ -8,26 +8,17 @@
 import UIKit
 import Combine
 
-protocol SceneCoordinatorType {
+final class SceneCoordinator {
   
-  @discardableResult
-  func tabTransition() -> AnyPublisher<Void, TransitionError>
+  static let shared: SceneCoordinator = .init()
   
-  @discardableResult
-  func transition(scene: Scene, using style: TransitionStyle, animated: Bool) -> AnyPublisher<Void, TransitionError>
-  
-  @discardableResult
-  func close(animated: Bool) -> AnyPublisher<Void, TransitionError>
-}
-
-final class SceneCoordinator: SceneCoordinatorType {
-  
-  private var window: UIWindow
+  private var window: UIWindow?
   private var currentViewController: UIViewController?
   
-  required init(window: UIWindow) {
+  private init() { }
+  
+  func setup(with window: UIWindow) {
     self.window = window
-    self.currentViewController = window.rootViewController
   }
   
   @discardableResult
@@ -35,7 +26,7 @@ final class SceneCoordinator: SceneCoordinatorType {
     return Future { [weak self] promise in
       // MARK: - 로직 수정 필요함 ㅠㅠ
       guard
-        let tabBarController: UITabBarController = self?.window.rootViewController as? UITabBarController,
+        let tabBarController: UITabBarController = self?.window?.rootViewController as? UITabBarController,
         let tabBarItems: [UIViewController] = tabBarController.viewControllers
       else {
         promise(.failure(TransitionError.unknown))
@@ -64,7 +55,7 @@ final class SceneCoordinator: SceneCoordinatorType {
       switch style {
       case .root:
         self?.currentViewController = target
-        self?.window.rootViewController = target
+        self?.window?.rootViewController = target
         promise(.success(()))
         
       case .push:

--- a/ZURAZU/ZURAZU/SceneDelegate.swift
+++ b/ZURAZU/ZURAZU/SceneDelegate.swift
@@ -17,9 +17,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     guard let window: UIWindow = window else { return }
     
-    let coordinator: SceneCoordinator = .init(window: window)
-    coordinator.transition(scene: MainTabBarScene(sceneCoordinator: coordinator), using: .root, animated: false)
-    coordinator.tabTransition()
+    SceneCoordinator.shared.setup(with: window)
+    SceneCoordinator.shared.transition(scene: MainTabBarScene(), using: .root, animated: false)
+    SceneCoordinator.shared.tabTransition()
     window.makeKeyAndVisible()
   }
 

--- a/ZURAZU/ZURAZU/SignIn/View/SignInScene.swift
+++ b/ZURAZU/ZURAZU/SignIn/View/SignInScene.swift
@@ -12,7 +12,6 @@ struct SignInScene: Scene {
   var storyboard: String {
     return "SignIn"
   }
-  var sceneCoordinator: SceneCoordinatorType
   
   func instantiate() -> UIViewController {
     guard var signInViewController: SignInViewController = viewController(identifier: .signInVC) as? SignInViewController else { fatalError() }


### PR DESCRIPTION
## 구현내용
- SceneCoordinator Singleton으로 변경
- Singleton으로 변경됨에 따른 코드 수정

### 화면(optional)
X

### 학습 내용(optional)
X

## 논의사항
- SceneCoordinator를 singletone으로 변경하면서 SceneCoordinatorType 프로토콜의 의미가 없어져서 같이 삭제했습니다.
- SceneCoordinator.shared.setup(with:) 메서드의 경우 SceneDelegate에서 최초 한번만 호출해줘야합니다!
