### PR TITLE
[FEAT] email password 관련 로직 수정

### DIFF
--- a/ZURAZU/ZURAZU/SignIn/View/InputView.swift
+++ b/ZURAZU/ZURAZU/SignIn/View/InputView.swift
@@ -59,6 +59,8 @@ private extension InputView {
   }
   
   func setupView() {
+    textField.clearButtonMode = .always
+    
     textField.placeholder = inputViewType.placeHolder
     textField.layer.borderColor = .none
     textField.backgroundColor = .background

--- a/ZURAZU/ZURAZU/SignIn/View/SignInViewController.swift
+++ b/ZURAZU/ZURAZU/SignIn/View/SignInViewController.swift
@@ -64,14 +64,14 @@ final class SignInViewController: UIViewController, ViewModelBindableType {
     signInInputView.emailInputView.textField
       .returnPublisher
       .sink {
-        self.signInInputView.emailInputView.textField.endEditing(true)
+        self.signInInputView.emailInputView.textField.resignFirstResponder()
       }
       .store(in: &cancellables)
     
     signInInputView.emailInputView.textField
       .textPublisher
       .compactMap { $0 }
-      .filter { !$0.isEmpty }
+      .output(in: 2...)
       .sink { [weak self] in
         self?.viewModel?.email.send($0)
       }
@@ -80,7 +80,7 @@ final class SignInViewController: UIViewController, ViewModelBindableType {
     signInInputView.passwordInputView.textField
       .textPublisher
       .compactMap { $0 }
-      .filter { !$0.isEmpty }
+      .output(in: 2...)
       .sink { [weak self] in
         self?.viewModel?.password.send($0)
       }


### PR DESCRIPTION
## 구현내용
- clearButton 추가
- 최초 이후 textField가 비어 있어도 에러 메시지 출력

### 화면(optional)
#### iPhone 11
<img src="https://user-images.githubusercontent.com/41328839/120759342-e5978c00-c54d-11eb-838e-17ed0ffdc0f1.gif" width="350">

### 학습 내용(optional)
X

## 논의사항
- 로직이 복잡해 질 것 같아서 최초 이후에는 지속적으로 에러메시지를 보여줄 수 있도록 했습니다.
- email / password textField에 filter 를 미적용하고 output(in: 2...) 식으로 구현했습니다.

